### PR TITLE
terraform: github: allow admin write access

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -6,7 +6,7 @@ resource "github_branch_protection_v3" "default-branch-protection" {
 
   repository     = data.github_repository.fluentbit.name
   branch         = data.github_repository.fluentbit.default_branch
-  enforce_admins = true
+  enforce_admins = false
 
   required_pull_request_reviews {
     dismiss_stale_reviews           = true


### PR DESCRIPTION
As a maintainer I am happy to move forward and use best practices
through PRs and CI/checks. The problem I just found is that I could
not merge my own PR that passed the CI, this slow down things since
I am one of the 'few ones; working 24x7 on Fluent Bit.

Signed-off-by: Eduardo Silva <edsiper@gmail.com>