### PR TITLE
Refactor into composable job

### DIFF
--- a/.github/workflows/call-common.yaml
+++ b/.github/workflows/call-common.yaml
@@ -23,6 +23,8 @@ jobs:
   run-tests:
     name: update fluentbit infra with terraform
     runs-on: ubuntu-latest
+    env:
+      ignore_errors: ${{ inputs.ignore_errors }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -60,7 +62,7 @@ jobs:
       - name: Terraform fmt
         id: fmt
         run: terraform fmt -check
-        continue-on-error: ${{ inputs.ignore_errors == 'true' }}
+        continue-on-error: ${{ env.ignore_errors == 'true' }}
         working-directory: terraform
 
       - name: Terraform Init
@@ -77,4 +79,4 @@ jobs:
         id: plan
         run: terraform plan -no-color
         working-directory: terraform
-        continue-on-error: ${{ inputs.ignore_errors == 'true' }}
+        continue-on-error: ${{ env.ignore_errors }}

--- a/.github/workflows/call-common.yaml
+++ b/.github/workflows/call-common.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Terraform fmt
         id: fmt
         run: terraform fmt -check
-        continue-on-error: ${{ inputs.ignore_errors }}
+        continue-on-error: ${{ inputs.ignore_errors == 'true' }}
         working-directory: terraform
 
       - name: Terraform Init
@@ -77,4 +77,4 @@ jobs:
         id: plan
         run: terraform plan -no-color
         working-directory: terraform
-        continue-on-error: ${{ inputs.ignore_errors }}
+        continue-on-error: ${{ inputs.ignore_errors == 'true' }}

--- a/.github/workflows/call-common.yaml
+++ b/.github/workflows/call-common.yaml
@@ -1,0 +1,80 @@
+on:
+  workflow_call:
+    inputs:
+      continue-on-error:
+        type: boolean
+        required: true
+    secrets:
+      gcp_sa_key:
+        required: true
+      terraform_cloud_api_token:
+        required: true
+      cloudflare_token:
+        required: true
+      packet_net_token:
+        required: true
+      github_personal_access_token:
+        required: true
+      github_owner:
+        required: true
+
+name: Tests for pull requests
+jobs:
+  run-tests:
+    name: update fluentbit infra with terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.terraform_cloud_api_token }}
+
+      - name: Replace the GCP service account key
+        run: |
+          cat <<EOT >> default.auto.tfvars
+          gcp-sa-key    =  <<-EOF
+          ${{ secrets.gcp_sa_key }}
+          EOF
+          EOT
+        working-directory: terraform
+
+      - name: Replace the cloudflare token
+        run: sed -i -e "s/\$CLOUDFLARE_TOKEN/${{ secrets.cloudflare_token }}/g" default.auto.tfvars
+        working-directory: terraform
+
+      - name: Replace the packet.net token
+        run: sed -i -e "s/\$PACKET_NET_TOKEN/${{ secrets.packet_net_token }}/g" default.auto.tfvars
+        working-directory: terraform
+
+      - name: Replace the github.com token
+        run: sed -i -e "s/\$GITHUB_TOKEN/${{ secrets.github_personal_access_token }}/g" default.auto.tfvars
+        working-directory: terraform
+
+      - name: Replace the github.com owner
+        run: sed -i -e "s/\$GITHUB_OWNER/${{ secrets.github_owner }}/g" default.auto.tfvars
+        working-directory: terraform
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: ${{ inputs.continue-on-error }}
+        working-directory: terraform
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+        working-directory: terraform
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        working-directory: terraform
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        working-directory: terraform
+        continue-on-error: ${{ inputs.continue-on-error }}

--- a/.github/workflows/call-common.yaml
+++ b/.github/workflows/call-common.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      continue-on-error:
+      ignore_errors:
         type: boolean
         required: true
     secrets:
@@ -60,7 +60,7 @@ jobs:
       - name: Terraform fmt
         id: fmt
         run: terraform fmt -check
-        continue-on-error: ${{ inputs.continue-on-error }}
+        continue-on-error: ${{ inputs.ignore_errors }}
         working-directory: terraform
 
       - name: Terraform Init
@@ -77,4 +77,4 @@ jobs:
         id: plan
         run: terraform plan -no-color
         working-directory: terraform
-        continue-on-error: ${{ inputs.continue-on-error }}
+        continue-on-error: ${{ inputs.ignore_errors }}

--- a/.github/workflows/call-common.yaml
+++ b/.github/workflows/call-common.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Terraform fmt
         id: fmt
         run: terraform fmt -check
-        continue-on-error: ${{ env.ignore_errors == 'true' }}
+        continue-on-error: true
         working-directory: terraform
 
       - name: Terraform Init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     # TODO: replace staging_infra_updates with main
     uses: calyptia/fluent-bit-infra/.github/workflows/call-common.yaml@staging_infra_updates
     with:
-      continue-on-error: true
+      ignore_errors: true
     secrets:
       gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
       terraform_cloud_api_token: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ on:
 name: Deploy fluent-bit infra
 jobs:
   update-infra-common:
-    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@main
+    # TODO: replace staging_infra_updates with main
+    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@staging_infra_updates
     with:
       continue-on-error: true
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ name: Deploy fluent-bit infra
 jobs:
   update-infra-common:
     # TODO: replace staging_infra_updates with main
-    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@staging_infra_updates
+    uses: calyptia/fluent-bit-infra/.github/workflows/call-common.yaml@staging_infra_updates
     with:
       continue-on-error: true
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,68 +2,27 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 name: Deploy fluent-bit infra
 jobs:
-  update-infra:
-    name: update fluentbit infra with terraform
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  update-infra-common:
+    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@main
+    with:
+      continue-on-error: true
+    secrets:
+      gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+      terraform_cloud_api_token: ${{ secrets.TF_API_TOKEN }}
+      cloudflare_token: ${{ secrets.CLOUDFLARE_TOKEN }}
+      packet_net_token: ${{ secrets.PACKET_NET_TOKEN }}
+      github_personal_access_token: ${{ secrets.GH_PA_TOKEN }}
+      github_owner: ${{ secrets.GH_PA_OWNER }}
 
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-
-      - name: Replace the GCP service account key
-        run: |
-          cat <<EOT >> default.auto.tfvars
-          gcp-sa-key    =  <<-EOF
-          ${{ secrets.GCP_SA_KEY }}
-          EOF
-          EOT
-        working-directory: terraform
-
-      - name: Replace the cloudflare token
-        run: sed -i -e "s/\$CLOUDFLARE_TOKEN/${{ secrets.CLOUDFLARE_TOKEN }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Replace the packet.net token
-        run: sed -i -e "s/\$PACKET_NET_TOKEN/${{ secrets.PACKET_NET_TOKEN }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Replace the github.com token
-        run: sed -i -e "s/\$GITHUB_TOKEN/${{ secrets.GH_PA_TOKEN }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Replace the github.com owner
-        run: sed -i -e "s/\$GITHUB_OWNER/${{ secrets.GH_PA_OWNER }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Terraform fmt
-        id: fmt
-        run: terraform fmt -check
-        continue-on-error: true
-        working-directory: terraform
-
-      - name: Terraform Init
-        id: init
-        run: terraform init
-        working-directory: terraform
-
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-        working-directory: terraform
-
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan -no-color
-        continue-on-error: true
-        working-directory: terraform
-
+  update-infra-apply:
+      name: Apply infrastructure changes
+      needs: update-infra-common
+      runs-on: ubuntu-latest
+      steps:
       - name: Terraform Apply
         id: apply
         run: terraform apply -input=false -auto-approve

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,63 +2,18 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 name: Tests for pull requests
 jobs:
   run-tests:
-    name: update fluentbit infra with terraform
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-
-      - name: Replace the GCP service account key
-        run: |
-          cat <<EOT >> default.auto.tfvars
-          gcp-sa-key    =  <<-EOF
-          ${{ secrets.GCP_SA_KEY }}
-          EOF
-          EOT
-        working-directory: terraform
-
-      - name: Replace the cloudflare token
-        run: sed -i -e "s/\$CLOUDFLARE_TOKEN/${{ secrets.CLOUDFLARE_TOKEN }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Replace the packet.net token
-        run: sed -i -e "s/\$PACKET_NET_TOKEN/${{ secrets.PACKET_NET_TOKEN }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Replace the github.com token
-        run: sed -i -e "s/\$GITHUB_TOKEN/${{ secrets.GH_PA_TOKEN }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Replace the github.com owner
-        run: sed -i -e "s/\$GITHUB_OWNER/${{ secrets.GH_PA_OWNER }}/g" default.auto.tfvars
-        working-directory: terraform
-
-      - name: Terraform fmt
-        id: fmt
-        run: terraform fmt -check
-        continue-on-error: true
-        working-directory: terraform
-
-      - name: Terraform Init
-        id: init
-        run: terraform init
-        working-directory: terraform
-
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-        working-directory: terraform
-
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan -no-color
-        working-directory: terraform
+    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@main
+    with:
+      continue-on-error: false
+    secrets:
+      gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+      terraform_cloud_api_token: ${{ secrets.TF_API_TOKEN }}
+      cloudflare_token: ${{ secrets.CLOUDFLARE_TOKEN }}
+      packet_net_token: ${{ secrets.PACKET_NET_TOKEN }}
+      github_personal_access_token: ${{ secrets.GH_PA_TOKEN }}
+      github_owner: ${{ secrets.GH_PA_OWNER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     # TODO: replace staging_infra_updates with main
     uses: calyptia/fluent-bit-infra/.github/workflows/call-common.yaml@staging_infra_updates
     with:
-      continue-on-error: false
+      ignore_errors: false
     secrets:
       gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
       terraform_cloud_api_token: ${{ secrets.TF_API_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,8 @@ on:
 name: Tests for pull requests
 jobs:
   run-tests:
-    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@main
+    # TODO: replace staging_infra_updates with main
+    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@staging_infra_updates
     with:
       continue-on-error: false
     secrets:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ name: Tests for pull requests
 jobs:
   run-tests:
     # TODO: replace staging_infra_updates with main
-    uses: calyptia/fluent-bit-infra/.github/workflows/call-build-images.yaml@staging_infra_updates
+    uses: calyptia/fluent-bit-infra/.github/workflows/call-common.yaml@staging_infra_updates
     with:
       continue-on-error: false
     secrets:


### PR DESCRIPTION
Moved common usage to single job to make it clearer what each caller is doing, i.e. PRs do not apply.

Currently using the branch name as we have to if we want to run it, replace with `main` before merge.

A little fun with boolean inputs - they cannot be used in some contexts it appears.