### PR TITLE
terraform: resolve lock issues on installation

### DIFF
--- a/terraform/provision/github-runner.create.sh
+++ b/terraform/provision/github-runner.create.sh
@@ -20,10 +20,6 @@ done
 
 export RUNNER_ALLOW_RUNASROOT="1"
 
-echo "> Install dependencies..."
-sudo apt-get update
-sudo apt-get install -y curl jq
-
 echo "> Downloading actions runner ($GH_RUNNER_VERSION)..."
 curl -o actions.tar.gz --location "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-${RUNNER_LABEL}-${GH_RUNNER_VERSION}.tar.gz"
 

--- a/terraform/provision/user-data.sh
+++ b/terraform/provision/user-data.sh
@@ -10,7 +10,8 @@ sed -i '/Defaults \+secure_path/s/^/#/' /etc/sudoers
 # do not require password
 sed -i '0,/%sudo/s/ALL$/NOPASSWD: ALL/' /etc/sudoers
 
-# Add docker
-apt-get update
-apt-get install -y docker.io
+# Add dependencies and allow for other users of apt-get
+# https://blog.sinjakli.co.uk/2021/10/25/waiting-for-apt-locks-without-the-hacky-bash-scripts/
+apt-get -o DPkg::Lock::Timeout=60 update
+apt-get -o DPkg::Lock::Timeout=-1 install -y docker.io curl jq
 usermod -aG docker provisioner


### PR DESCRIPTION
There is a potential race with installation of dependencies if another process is doing the same and therefore the lock cannot be captured. This change uses a timeout to keep retrying.

Signed-off-by: Patrick Stephens <pat@calyptia.com>