### PR TITLE
terraform: support mirror secrets

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -27,21 +27,7 @@ resource "github_branch_default" "mirror-default-branch"{
   branch     = github_branch.mirror-main-branch.branch
 }
 
-# Minimal branch protection - required for environment set up later.
-resource "github_branch_protection_v3" "mirror-main-branch-protection" {
-  repository     = data.github_repository.fluent-bit-mirror.name
-  branch         = github_branch.mirror-main-branch.branch
-  enforce_admins = true
-
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    require_code_owner_reviews      = true
-    required_approving_review_count = 1
-}
-
-  # No status checks - we do not want to force unit tests, etc. to run
-  # TODO: update with checks on incoming syncs
-}
+# No branch protection or environments supported for the private repos like the mirror
 
 # We only want this for the normal Fluent Bit repository.
 resource "github_branch_protection_v3" "default-branch-protection" {
@@ -61,21 +47,14 @@ resource "github_branch_protection_v3" "default-branch-protection" {
   }
 }
 
-# We create an array for the rest of the Terraform configuration to loop over on each repository
-locals {
-  fluent-bit-repos = [ data.github_repository.fluentbit, data.github_repository.fluent-bit-mirror ]
-}
-
 data "github_user" "release-approvers-users" {
     for_each = var.release-approvers-usernames
     username = each.value
 }
 
 resource "github_repository_environment" "release-environment" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
   environment = "release"
-  repository  = each.value.name
+  repository  = data.github_repository.fluentbit
   reviewers {
     users = [ for user in data.github_user.release-approvers-users: user.id ]
   }
@@ -87,121 +66,95 @@ resource "github_repository_environment" "release-environment" {
 
 # The packaging server to use:
 resource "github_actions_environment_secret" "release-server-hostname" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "FLUENTBITIO_HOST"
   plaintext_value = var.release-server-hostname
 }
 
 resource "github_actions_environment_secret" "release-server-username" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "FLUENTBITIO_USERNAME"
   plaintext_value = var.release-server-username
 }
 
 resource "github_actions_environment_secret" "release-server-sshkey" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "FLUENTBITIO_SSHKEY"
   plaintext_value = var.release-server-sshkey
 }
 
 # The DockerHub details for release
 resource "github_actions_environment_secret" "release-dockerhub-username" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "DOCKERHUB_USERNAME"
   plaintext_value = var.release-dockerhub-username
 }
 
 resource "github_actions_environment_secret" "release-dockerhub-token" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "DOCKERHUB_TOKEN"
   plaintext_value = var.release-dockerhub-token
 }
 resource "github_actions_environment_secret" "release-dockerhub-org" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "DOCKERHUB_ORGANIZATION"
   plaintext_value = var.release-dockerhub-org
 }
 
 # Cosign signatures for release
 resource "github_actions_environment_secret" "release-cosign-private-key" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "COSIGN_PRIVATE_KEY"
   plaintext_value = var.release-cosign-private-key
 }
 
 # AWS credentials
 resource "github_actions_environment_secret" "release-bucket-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "AWS_S3_BUCKET_RELEASE"
   plaintext_value = var.release-s3-bucket
 }
 
 # Release needs to take out of staging and into release bucket
 resource "github_actions_environment_secret" "release-staging-bucket-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "AWS_S3_BUCKET_STAGING"
   plaintext_value = var.staging-s3-bucket
 }
 
 resource "github_actions_environment_secret" "release-aws-access-key-id-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = var.release-s3-access-id
 }
 
 resource "github_actions_environment_secret" "release-aws-secret-access-key-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.release-s3-secret-access-key
 }
 
 resource "github_actions_environment_secret" "release-gpg-private-key-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.release-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.release-environment
   secret_name     = "GPG_PRIVATE_KEY"
   plaintext_value = var.release-gpg-key
 }
 
 resource "github_repository_environment" "staging-environment" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
   environment = "staging"
-  repository  = each.value.name
+  repository      = data.github_repository.fluentbit
   deployment_branch_policy {
     protected_branches     = true
     custom_branch_policies = false
@@ -209,37 +162,60 @@ resource "github_repository_environment" "staging-environment" {
 }
 
 resource "github_actions_environment_secret" "staging-bucket-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.staging-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.staging-environment
   secret_name     = "AWS_S3_BUCKET_STAGING"
   plaintext_value = var.staging-s3-bucket
 }
 
 resource "github_actions_environment_secret" "staging-aws-access-key-id-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.staging-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.staging-environment
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = var.staging-s3-access-id
 }
 
 resource "github_actions_environment_secret" "staging-aws-secret-access-key-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.staging-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.staging-environment
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.staging-s3-secret-access-key
 }
 
 resource "github_actions_environment_secret" "staging-gpg-private-key-secret" {
-  for_each = { for repo in local.fluent-bit-repos: repo.name => repo }
-
-  repository      = each.value.name
-  environment     = github_repository_environment.staging-environment[each.key].environment
+  repository      = data.github_repository.fluentbit
+  environment     = github_repository_environment.staging-environment
   secret_name     = "GPG_PRIVATE_KEY"
   plaintext_value = var.staging-gpg-key
+}
+
+# For the mirror we need release environment secrets but as full-blown repository secrets
+# as private repos do not support without Github Enterprise.
+# We unfortunately cannot splat them all together dynamically either:
+# https://github.com/hashicorp/terraform/issues/19931
+# Potentially we could do a post processing state list: https://www.terraform.io/cli/commands/state/list
+# To keep it simple we just list them.
+# We may need staging secrets separately if we want to sign with a different key or use different S3 access.
+locals {
+  mirror-release-secrets = [
+    github_actions_environment_secret.release-server-hostname,
+    github_actions_environment_secret.release-server-username,
+    github_actions_environment_secret.release-server-sshkey,
+    github_actions_environment_secret.release-dockerhub-username,
+    github_actions_environment_secret.release-dockerhub-token,
+    github_actions_environment_secret.release-dockerhub-org,
+    github_actions_environment_secret.release-cosign-private-key,
+    github_actions_environment_secret.release-bucket-secret,
+    github_actions_environment_secret.release-staging-bucket-secret,
+    github_actions_environment_secret.release-aws-secret-access-key-secret,
+    github_actions_environment_secret.release-gpg-private-key-secret
+  ]
+}
+
+resource "github_actions_secret" "mirror-release-secrets" {
+  for_each = { for secret in local.mirror-release-secrets: secret.secret_name => secret }
+
+  repository      = data.github_repository.fluent-bit-mirror
+  secret_name     = each.key
+  encrypted_value = each.value.encrypted_value
 }

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -67,21 +67,21 @@ resource "github_repository_environment" "release-environment" {
 # The packaging server to use:
 resource "github_actions_environment_secret" "release-server-hostname" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "FLUENTBITIO_HOST"
   plaintext_value = var.release-server-hostname
 }
 
 resource "github_actions_environment_secret" "release-server-username" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "FLUENTBITIO_USERNAME"
   plaintext_value = var.release-server-username
 }
 
 resource "github_actions_environment_secret" "release-server-sshkey" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "FLUENTBITIO_SSHKEY"
   plaintext_value = var.release-server-sshkey
 }
@@ -89,20 +89,20 @@ resource "github_actions_environment_secret" "release-server-sshkey" {
 # The DockerHub details for release
 resource "github_actions_environment_secret" "release-dockerhub-username" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "DOCKERHUB_USERNAME"
   plaintext_value = var.release-dockerhub-username
 }
 
 resource "github_actions_environment_secret" "release-dockerhub-token" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "DOCKERHUB_TOKEN"
   plaintext_value = var.release-dockerhub-token
 }
 resource "github_actions_environment_secret" "release-dockerhub-org" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "DOCKERHUB_ORGANIZATION"
   plaintext_value = var.release-dockerhub-org
 }
@@ -110,7 +110,7 @@ resource "github_actions_environment_secret" "release-dockerhub-org" {
 # Cosign signatures for release
 resource "github_actions_environment_secret" "release-cosign-private-key" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "COSIGN_PRIVATE_KEY"
   plaintext_value = var.release-cosign-private-key
 }
@@ -118,7 +118,7 @@ resource "github_actions_environment_secret" "release-cosign-private-key" {
 # AWS credentials
 resource "github_actions_environment_secret" "release-bucket-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "AWS_S3_BUCKET_RELEASE"
   plaintext_value = var.release-s3-bucket
 }
@@ -126,28 +126,28 @@ resource "github_actions_environment_secret" "release-bucket-secret" {
 # Release needs to take out of staging and into release bucket
 resource "github_actions_environment_secret" "release-staging-bucket-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "AWS_S3_BUCKET_STAGING"
   plaintext_value = var.staging-s3-bucket
 }
 
 resource "github_actions_environment_secret" "release-aws-access-key-id-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = var.release-s3-access-id
 }
 
 resource "github_actions_environment_secret" "release-aws-secret-access-key-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.release-s3-secret-access-key
 }
 
 resource "github_actions_environment_secret" "release-gpg-private-key-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.release-environment
+  environment     = github_repository_environment.release-environment.environment
   secret_name     = "GPG_PRIVATE_KEY"
   plaintext_value = var.release-gpg-key
 }
@@ -163,28 +163,28 @@ resource "github_repository_environment" "staging-environment" {
 
 resource "github_actions_environment_secret" "staging-bucket-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.staging-environment
+  environment     = github_repository_environment.staging-environment.environment
   secret_name     = "AWS_S3_BUCKET_STAGING"
   plaintext_value = var.staging-s3-bucket
 }
 
 resource "github_actions_environment_secret" "staging-aws-access-key-id-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.staging-environment
+  environment     = github_repository_environment.staging-environment.environment
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = var.staging-s3-access-id
 }
 
 resource "github_actions_environment_secret" "staging-aws-secret-access-key-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.staging-environment
+  environment     = github_repository_environment.staging-environment.environment
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.staging-s3-secret-access-key
 }
 
 resource "github_actions_environment_secret" "staging-gpg-private-key-secret" {
   repository      = data.github_repository.fluentbit.name
-  environment     = github_repository_environment.staging-environment
+  environment     = github_repository_environment.staging-environment.environment
   secret_name     = "GPG_PRIVATE_KEY"
   plaintext_value = var.staging-gpg-key
 }

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -54,7 +54,7 @@ data "github_user" "release-approvers-users" {
 
 resource "github_repository_environment" "release-environment" {
   environment = "release"
-  repository  = data.github_repository.fluentbit
+  repository  = data.github_repository.fluentbit.name
   reviewers {
     users = [ for user in data.github_user.release-approvers-users: user.id ]
   }
@@ -66,21 +66,21 @@ resource "github_repository_environment" "release-environment" {
 
 # The packaging server to use:
 resource "github_actions_environment_secret" "release-server-hostname" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "FLUENTBITIO_HOST"
   plaintext_value = var.release-server-hostname
 }
 
 resource "github_actions_environment_secret" "release-server-username" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "FLUENTBITIO_USERNAME"
   plaintext_value = var.release-server-username
 }
 
 resource "github_actions_environment_secret" "release-server-sshkey" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "FLUENTBITIO_SSHKEY"
   plaintext_value = var.release-server-sshkey
@@ -88,20 +88,20 @@ resource "github_actions_environment_secret" "release-server-sshkey" {
 
 # The DockerHub details for release
 resource "github_actions_environment_secret" "release-dockerhub-username" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "DOCKERHUB_USERNAME"
   plaintext_value = var.release-dockerhub-username
 }
 
 resource "github_actions_environment_secret" "release-dockerhub-token" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "DOCKERHUB_TOKEN"
   plaintext_value = var.release-dockerhub-token
 }
 resource "github_actions_environment_secret" "release-dockerhub-org" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "DOCKERHUB_ORGANIZATION"
   plaintext_value = var.release-dockerhub-org
@@ -109,7 +109,7 @@ resource "github_actions_environment_secret" "release-dockerhub-org" {
 
 # Cosign signatures for release
 resource "github_actions_environment_secret" "release-cosign-private-key" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "COSIGN_PRIVATE_KEY"
   plaintext_value = var.release-cosign-private-key
@@ -117,7 +117,7 @@ resource "github_actions_environment_secret" "release-cosign-private-key" {
 
 # AWS credentials
 resource "github_actions_environment_secret" "release-bucket-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "AWS_S3_BUCKET_RELEASE"
   plaintext_value = var.release-s3-bucket
@@ -125,28 +125,28 @@ resource "github_actions_environment_secret" "release-bucket-secret" {
 
 # Release needs to take out of staging and into release bucket
 resource "github_actions_environment_secret" "release-staging-bucket-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "AWS_S3_BUCKET_STAGING"
   plaintext_value = var.staging-s3-bucket
 }
 
 resource "github_actions_environment_secret" "release-aws-access-key-id-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = var.release-s3-access-id
 }
 
 resource "github_actions_environment_secret" "release-aws-secret-access-key-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.release-s3-secret-access-key
 }
 
 resource "github_actions_environment_secret" "release-gpg-private-key-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.release-environment
   secret_name     = "GPG_PRIVATE_KEY"
   plaintext_value = var.release-gpg-key
@@ -154,7 +154,7 @@ resource "github_actions_environment_secret" "release-gpg-private-key-secret" {
 
 resource "github_repository_environment" "staging-environment" {
   environment = "staging"
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   deployment_branch_policy {
     protected_branches     = true
     custom_branch_policies = false
@@ -162,28 +162,28 @@ resource "github_repository_environment" "staging-environment" {
 }
 
 resource "github_actions_environment_secret" "staging-bucket-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.staging-environment
   secret_name     = "AWS_S3_BUCKET_STAGING"
   plaintext_value = var.staging-s3-bucket
 }
 
 resource "github_actions_environment_secret" "staging-aws-access-key-id-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.staging-environment
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = var.staging-s3-access-id
 }
 
 resource "github_actions_environment_secret" "staging-aws-secret-access-key-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.staging-environment
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.staging-s3-secret-access-key
 }
 
 resource "github_actions_environment_secret" "staging-gpg-private-key-secret" {
-  repository      = data.github_repository.fluentbit
+  repository      = data.github_repository.fluentbit.name
   environment     = github_repository_environment.staging-environment
   secret_name     = "GPG_PRIVATE_KEY"
   plaintext_value = var.staging-gpg-key

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -215,7 +215,7 @@ locals {
 resource "github_actions_secret" "mirror-release-secrets" {
   for_each = { for secret in local.mirror-release-secrets: secret.secret_name => secret }
 
-  repository      = data.github_repository.fluent-bit-mirror
+  repository      = data.github_repository.fluent-bit-mirror.name
   secret_name     = each.key
   encrypted_value = each.value.encrypted_value
 }


### PR DESCRIPTION
Unfortunately the mirror does not support environments or their associated secrets without a Github Enterprise subscription: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
There's no good way to get a dynamic list of those secrets in Terraform so we manage it via an explicit list.
Branch protection also seems to not be available for private repos.

Because we remove the array of repos, we have to destroy and recreate the secrets but they're only on the staging + release environments anyway.

Signed-off-by: Patrick Stephens <pat@calyptia.com>